### PR TITLE
Corrige old_attributes

### DIFF
--- a/src/LogBehavior.php
+++ b/src/LogBehavior.php
@@ -22,9 +22,9 @@ class LogBehavior extends Behavior {
 
         if (isset($this->ignoreLogBehavior) && $this->ignoreLogBehavior)
             return;
-
+        $oldAttributes = array_merge($model->oldAttributes, $event->changedAttributes);
         Log::l(
-            $model->oldAttributes,
+            $oldAttributes,
             $model->attributes,
             $event,
             $model::className(),


### PR DESCRIPTION
Actualmente old_attributes tiene el mismo valor que attributes. 
Con este PR se obtienen los valores previos a la modificación de los campos del modelo y se genera el old_attribute